### PR TITLE
FIX: compatibility with discourse-encrypt

### DIFF
--- a/assets/javascripts/initializers/inline-footnotes.js.es6
+++ b/assets/javascripts/initializers/inline-footnotes.js.es6
@@ -6,7 +6,7 @@ function showFootnote() {
     .prev()
     .find("a")[0].href;
   id = "#" + id.split("#")[1];
-  let html = $(id).html();
+  let html = $(this).parents(".cooked").find(id).html();
 
   $("#footnote-tooltip").remove();
 


### PR DESCRIPTION
For "normal" post, reference ID includes post id in cooked body:

https://github.com/discourse/discourse-footnote/blob/master/plugin.rb#L18

However, for encrypted messages we cannot relay on cooked body. Therefore when reference is looked up it should be searched in current post.

Otherwise, when we have 2 posts in with footnotes, always footnote from first post is found