### PR TITLE
SECURITY: Fix malicious footnote causing clientside errors

### DIFF
--- a/assets/javascripts/initializers/inline-footnotes.js
+++ b/assets/javascripts/initializers/inline-footnotes.js
@@ -8,14 +8,20 @@ function applyInlineFootnotes(elem) {
   const footnoteRefs = elem.querySelectorAll("sup.footnote-ref");
 
   footnoteRefs.forEach((footnoteRef) => {
+    const refLink = footnoteRef.querySelector("a");
+    if (!refLink) {
+      return;
+    }
+
     const expandableFootnote = document.createElement("a");
     expandableFootnote.classList.add("expand-footnote");
     expandableFootnote.innerHTML = iconHTML("ellipsis-h");
     expandableFootnote.href = "";
     expandableFootnote.role = "button";
-    expandableFootnote.dataset.footnoteId = footnoteRef
-      .querySelector("a")
-      .id.replace("footnote-ref-", "");
+    expandableFootnote.dataset.footnoteId = refLink.id.replace(
+      "footnote-ref-",
+      ""
+    );
 
     footnoteRef.after(expandableFootnote);
   });

--- a/assets/vendor/javascripts/markdown-it-footnote.js
+++ b/assets/vendor/javascripts/markdown-it-footnote.js
@@ -212,6 +212,15 @@ module.exports = function footnote_plugin(md) {
         tokens = []
       );
 
+      // Having a rendered footnote inside a link creates a nested link, which
+      // is not valid HTML, so close the parent tag first before proceeding.
+      const previousToken = state.tokens[state.tokens.length - 1];
+      if (previousToken?.content.includes("<a")) {
+        const linkCloseToken = state.push("html_inline", "", 0);
+        linkCloseToken.content = "</a>";
+        linkCloseToken.block = false;
+      }
+
       token      = state.push('footnote_ref', '', 0);
       token.meta = { id: footnoteId };
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 # transpile_js: true
 # name: discourse-footnote
 # about: Adds markdown.it footnote support to Discourse
-# version: 0.1
+# version: 0.2
 # authors: Sam Saffron, Vitaly Puzrin
 # url: https://github.com/discourse/discourse-footnote
 

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -87,4 +87,31 @@ describe PrettyText do
 
   end
 
+  it "supports inline footnotes wrapped in <a> elements by ending the elements early" do
+    raw = <<~MD
+      I have a point, see footnote. <a>^[the point]</a>
+
+      <a>^[footnote]</a>
+    MD
+
+    post = create_post(raw: raw)
+    post.reload
+
+    html = <<~HTML
+      <p>I have a point, see footnote. <a></a><sup class="footnote-ref"><a href="#footnote-#{post.id}-1" id="footnote-ref-#{post.id}-1">[1]</a></sup></p>
+      <p><a></a><sup class="footnote-ref"><a href="#footnote-#{post.id}-2" id="footnote-ref-#{post.id}-2">[2]</a></sup></p>
+      <hr class="footnotes-sep">
+
+      <ol class="footnotes-list">
+      <li id="footnote-#{post.id}-1" class="footnote-item">
+      <p>the point <a href="#footnote-ref-#{post.id}-1" class="footnote-backref">↩︎</a></p>
+      </li>
+      <li id="footnote-#{post.id}-2" class="footnote-item">
+      <p>footnote <a href="#footnote-ref-#{post.id}-2" class="footnote-backref">↩︎</a></p>
+      </li>
+      </ol>
+    HTML
+
+    expect(post.cooked.strip).to eq(html.strip)
+  end
 end


### PR DESCRIPTION
Some malformed/malicious footnote markup could cause
clientside errors.