### PR TITLE
FIX: Fix footnotes in encrypted PMs

### DIFF
--- a/assets/javascripts/initializers/inline-footnotes.js
+++ b/assets/javascripts/initializers/inline-footnotes.js
@@ -67,7 +67,17 @@ function footNoteEventHandler(event) {
   const cooked = expandableFootnote.closest(".cooked");
   const footnoteId = expandableFootnote.dataset.footnoteId;
   const footnoteContent = tooltip.querySelector(".footnote-tooltip-content");
-  const newContent = cooked.querySelector(`#footnote-${footnoteId}`);
+  let newContent = cooked.querySelector(`#footnote-${footnoteId}`);
+  if (!newContent) {
+    // when we're in an encrypted PM, the elements we need don't have the IDs
+    // that are added by the server-side processor (see plugin.rb).
+    //
+    // so we have to work with the original IDs that the markdown-it library
+    // adds which isn't great because if multiple posts include footnotes then
+    // we'll have some elements in the DOM with identical IDs...
+    const id = footnoteId.match(/^fnref(\d+)$/)[1];
+    newContent = cooked.querySelector(`#fn${id}`);
+  }
   footnoteContent.innerHTML = newContent.innerHTML;
 
   // remove backref from tooltip


### PR DESCRIPTION
The plugin currently doesn't work in encrypted PMs; if you click on the <kbd>...</kbd> inside an encrypted PM, an error occurs at line 71 because `newContent` is `null`:

https://github.com/discourse/discourse-footnote/blob/df9c22642c05846343386ad82ddac1511516da06/assets/javascripts/initializers/inline-footnotes.js#L70-L71

The markdown-it library that we use to implement footnotes produces HTML elements that become part of a post's cooked HTML. Then we have a server-side posts processor that overrides the ids of the elements that are produced by the library:

https://github.com/discourse/discourse-footnote/blob/df9c22642c05846343386ad82ddac1511516da06/plugin.rb#L17-L40

We do this to avoid having multiple DOM elements with identical ids when multiple posts in the same topic include footnotes. So for example `#fn<id>` becomes `#footnote-<post_id>-<id>`. However, with encrypted PMs the server doesn't process posts content at all and so the ids that we expect don't exist and we only have the original IDs that are added by the library.

The plugin used to work with discourse-encrypt, but I'm not sure how; I don't see any logic in this plugin or discourse-encrypt that handles footnotes for encrypted PMs.

Thoughts on this approach @jjaffeux?