### PR TITLE
FIX: removes footnote btn from text selection

### DIFF
--- a/assets/stylesheets/footnotes.scss
+++ b/assets/stylesheets/footnotes.scss
@@ -1,5 +1,6 @@
 .inline-footnotes {
   a.expand-footnote {
+    user-select: none;
     padding: 0px 0.5em;
     margin: 0 0 0 0.25em;
     color: var(--primary-low-mid-or-secondary-high);


### PR DESCRIPTION
This was causing an issue on Firefox where the selection would stop at the button.