### PR TITLE
FIX: Allow multiple references to same footnote

### DIFF
--- a/assets/javascripts/initializers/inline-footnotes.js
+++ b/assets/javascripts/initializers/inline-footnotes.js
@@ -18,10 +18,7 @@ function applyInlineFootnotes(elem) {
     expandableFootnote.innerHTML = iconHTML("ellipsis-h");
     expandableFootnote.href = "";
     expandableFootnote.role = "button";
-    expandableFootnote.dataset.footnoteId = refLink.id.replace(
-      "footnote-ref-",
-      ""
-    );
+    expandableFootnote.dataset.footnoteId = refLink.getAttribute("href");
 
     footnoteRef.after(expandableFootnote);
   });
@@ -67,22 +64,9 @@ function footNoteEventHandler(event) {
   const cooked = expandableFootnote.closest(".cooked");
   const footnoteId = expandableFootnote.dataset.footnoteId;
   const footnoteContent = tooltip.querySelector(".footnote-tooltip-content");
-  let newContent = cooked.querySelector(`#footnote-${footnoteId}`);
-  if (!newContent) {
-    // when we're in an encrypted PM, the elements we need don't have the IDs
-    // that are added by the server-side processor (see plugin.rb).
-    //
-    // so we have to work with the original IDs that the markdown-it library
-    // adds which isn't great because if multiple posts include footnotes then
-    // we'll have some elements in the DOM with identical IDs...
-    const id = footnoteId.match(/^fnref(\d+)$/)[1];
-    newContent = cooked.querySelector(`#fn${id}`);
-  }
-  footnoteContent.innerHTML = newContent.innerHTML;
+  let newContent = cooked.querySelector(footnoteId);
 
-  // remove backref from tooltip
-  const backRef = footnoteContent.querySelector(".footnote-backref");
-  backRef.parentNode.removeChild(backRef);
+  footnoteContent.innerHTML = newContent.innerHTML;
 
   // display tooltip
   tooltip.dataset.show = "";

--- a/assets/stylesheets/footnotes.scss
+++ b/assets/stylesheets/footnotes.scss
@@ -52,6 +52,10 @@
   .footnote-tooltip-content {
     overflow: hidden;
 
+    .footnote-backref {
+      display: none;
+    }
+
     img {
       object-fit: cover;
       max-width: 385px;

--- a/test/javascripts/acceptance/footnote-test.js
+++ b/test/javascripts/acceptance/footnote-test.js
@@ -16,6 +16,7 @@ acceptance("Discourse Foonote Plugin", function (needs) {
       let topic = cloneJSON(topicFixtures["/t/28830/1.json"]);
       topic["post_stream"]["posts"][0]["cooked"] = `
         <p>Lorem ipsum dolor sit amet<sup class="footnote-ref"><a href="#footnote-17-1" id="footnote-ref-17-1">[1]</a></sup></p>
+        <p class="second">Second reference should also work. <sup class="footnote-ref"><a href="#footnote-17-1" id="footnote-ref-17-0">[1]</a></sup></p>
         <hr class="footnotes-sep">
         <ol class="footnotes-list">
           <li id="footnote-17-1" class="footnote-item">
@@ -35,8 +36,23 @@ acceptance("Discourse Foonote Plugin", function (needs) {
 
     await click(".expand-footnote");
 
-    const tooltipContent = tooltip.querySelector(".footnote-tooltip-content")
-      .innerText;
-    assert.equal(tooltipContent, "consectetur adipiscing elit");
+    assert.equal(
+      tooltip.querySelector(".footnote-tooltip-content").innerText,
+      "consectetur adipiscing elit"
+    );
+  });
+
+  test("clicking a second footnote with same name works", async function (assert) {
+    await visit("/t/45");
+
+    const tooltip = document.getElementById("footnote-tooltip");
+    assert.ok(exists(tooltip));
+
+    await click(".second .expand-footnote");
+
+    assert.equal(
+      tooltip.querySelector(".footnote-tooltip-content").innerText,
+      "consectetur adipiscing elit"
+    );
   });
 });

--- a/test/javascripts/acceptance/footnote-test.js
+++ b/test/javascripts/acceptance/footnote-test.js
@@ -38,7 +38,7 @@ acceptance("Discourse Foonote Plugin", function (needs) {
 
     assert.equal(
       tooltip.querySelector(".footnote-tooltip-content").innerText,
-      "consectetur adipiscing elit"
+      "consectetur adipiscing elit ↩︎"
     );
   });
 
@@ -52,7 +52,7 @@ acceptance("Discourse Foonote Plugin", function (needs) {
 
     assert.equal(
       tooltip.querySelector(".footnote-tooltip-content").innerText,
-      "consectetur adipiscing elit"
+      "consectetur adipiscing elit ↩︎"
     );
   });
 });


### PR DESCRIPTION
Switches to using `href` instead of `id` when referencing a footnote, so that multiple references can correctly point to the same one. This also matches anchors better, makes for simpler code. (See also bug report at https://meta.discourse.org/t/footnote-sample-no-longer-working/222756.) 

@OsamaSayegh I believe this works for encrypted messages as well (tested locally), hence we no longer need the code added in https://github.com/discourse/discourse-footnote/commit/f37543eaf1ff91adbb15c64a3b70b9e4790cc77b. Just checking that this wasn't something else. 