### PR TITLE
FIX: Do not registerPlugin if no window.markdownitFootnote

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/footnotes.js
+++ b/assets/javascripts/lib/discourse-markdown/footnotes.js
@@ -1,6 +1,7 @@
 export function setup(helper) {
   helper.registerOptions((opts, siteSettings) => {
-    opts.features["footnotes"] = !!siteSettings.enable_markdown_footnotes;
+    opts.features["footnotes"] =
+      window.markdownitFootnote && !!siteSettings.enable_markdown_footnotes;
   });
 
   helper.allowList([
@@ -19,5 +20,7 @@ export function setup(helper) {
     },
   });
 
-  helper.registerPlugin(window.markdownitFootnote);
+  if (window.markdownitFootnote) {
+    helper.registerPlugin(window.markdownitFootnote);
+  }
 }


### PR DESCRIPTION
In certain environments (e.g. QUnit tests) window.markdownitFootnote may not be present, in this case we do not want to try register the markdown plugin since it will result in errors from MarkdownIt.use()