### PR TITLE
DEV: Ensure tests work when plugin CSS is loaded

### DIFF
--- a/test/javascripts/acceptance/footnote-test.js
+++ b/test/javascripts/acceptance/footnote-test.js
@@ -35,9 +35,8 @@ acceptance("Discourse Foonote Plugin", function (needs) {
     assert.ok(exists(tooltip));
 
     await click(".expand-footnote");
-
     assert.equal(
-      tooltip.querySelector(".footnote-tooltip-content").innerText,
+      tooltip.querySelector(".footnote-tooltip-content").textContent.trim(),
       "consectetur adipiscing elit ↩︎"
     );
   });
@@ -51,7 +50,7 @@ acceptance("Discourse Foonote Plugin", function (needs) {
     await click(".second .expand-footnote");
 
     assert.equal(
-      tooltip.querySelector(".footnote-tooltip-content").innerText,
+      tooltip.querySelector(".footnote-tooltip-content").textContent.trim(),
       "consectetur adipiscing elit ↩︎"
     );
   });


### PR DESCRIPTION
CSS can slightly affect the result of element.innerText. Preparation for https://github.com/discourse/discourse/pull/18668