### PR TITLE
UX: prevent long strings from causing mobile overflow

### DIFF
--- a/assets/stylesheets/footnotes.scss
+++ b/assets/stylesheets/footnotes.scss
@@ -25,6 +25,10 @@
   .footnotes-list,
   .footnotes-sep {
     position: absolute;
+    // the left/right positioning prevents overflow issues
+    // with long words causing overflow on small screens
+    left: 0;
+    right: 0;
   }
 
   .footnotes-sep,


### PR DESCRIPTION
This solves a mobile topic horizontal overflow issue with long strings in footnotes. Previous to this fix, an unbroken string wider than the viewport would cause overflow... this is because there's a `visibility: hidden;` container here to force the browser to lazy-load images, and it's absolutely positioned. The absolute position means it's not restricted by its parent container, and can overflow in cases where there are long strings. 

Adding left/right positioning constrains this container, preventing overflow. 

Before:
![Screenshot 2022-12-09 at 2 22 20 PM](https://user-images.githubusercontent.com/1681963/206781193-c01b16ef-320b-4276-8dae-ca0129e6daa2.png)

After: 
![Screenshot 2022-12-09 at 2 21 41 PM](https://user-images.githubusercontent.com/1681963/206781192-8aa84c2a-80b2-404c-8bb3-71373d0616bf.png)

see /t/87686
