### PR TITLE
UX: Fix height issues with inline footnotes

### DIFF
--- a/assets/stylesheets/footnotes.scss
+++ b/assets/stylesheets/footnotes.scss
@@ -33,10 +33,6 @@
 
   .footnotes-sep,
   .footnotes-list,
-  .footnote-backref {
-    visibility: hidden;
-  }
-
   .footnote-ref {
     display: none;
   }


### PR DESCRIPTION
`visibility: hidden` still takes up space, so the footnotes were causing the height of the post to be larger than it should be in some cases (tall images in the footnote, or lots of text in it).

This switches to hiding the list and separator. (When footnotes are inlined, the `footnote-backref` element is inside the list, so it's already hidden).

See t/98004 internally.