### PR TITLE
FIX: Use a regular string for admin notification

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -8,8 +8,6 @@
 
 after_initialize do
   AdminDashboardData.add_problem_check do
-    I18n.t(
-      "The discourse-footnote plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container.",
-    )
+    "The discourse-footnote plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container."
   end
 end


### PR DESCRIPTION
The plugin is now part of core and translations are no longer part of
this plugin repo.

This is also what we have done for another plugin that was added to
core: https://github.com/discourse/discourse-checklist/blob/main/plugin.rb#L12
